### PR TITLE
remove max-width to make page responsive

### DIFF
--- a/src/pages/LeaderBoard.jsx
+++ b/src/pages/LeaderBoard.jsx
@@ -18,7 +18,7 @@ const users = [
 function LeaderBoard() {
   return (
     <>
-      <div class="container max-w-md mx-auto flex flex-col">
+      <div class="container mx-auto flex flex-col">
         <Navbar>Competición</Navbar>
         <DisplayMode user={currentUser} />
         <p className="text-lg font-semibold m-6 text-black">


### PR DESCRIPTION
He quitado el max-width pero he dejado igualmente un container para evitar que ocupe el 100% de ancho en desktop