### PR TITLE
add bottom padding to disable content overlapping + text consistence …

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />

--- a/src/components/UserCard.jsx
+++ b/src/components/UserCard.jsx
@@ -18,7 +18,7 @@ const UserCard = () => {
           <h2 className="font-bold text-black">
             {user.name} {user.surname}
           </h2>
-          <p className="text-secondary font-bold text-xs mt-2">Semana 34</p>
+          <p className="text-secondary font-bold text-xs">Semana 34</p>
         </div>
       </div>
       <div className="flex flex-row ">

--- a/src/components/molecules/IndicatorGroup.jsx
+++ b/src/components/molecules/IndicatorGroup.jsx
@@ -8,8 +8,8 @@ const IndicatorGroup = ({ title, punctuation, children, points }) => {
         {children}
       </Indicator>
       {/* ==> estos valores tendrían que venir el user */}
-      <p className="text-sm mt-2 w-20 text-center">{title}</p>
-      <p className="text-secondary text-center mt-2">{punctuation}</p>
+      <p className="text-sm mt-2 w-20 text-center leading-tight">{title}</p>
+      <p className="text-secondary text-center mt-1">{punctuation}</p>
     </div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -13,3 +13,4 @@
 *{
   font-family: 'Poppins', sans-serif;
 }
+

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -10,7 +10,7 @@ function Home() {
   return (
     <>
       <Navbar>Resumen Semanal</Navbar>
-      <div className="w-screen h-screen bg-base pt-12">
+      <div className="w-full h-full bg-base pt-12 pb-12">
         <div className="flex items-start p-6">
           <h1 className="font-bold text-3xl">Hola {user.name}!</h1>
         </div>
@@ -23,7 +23,7 @@ function Home() {
         <div className="flex items-start ml-6 mt-4">
           <p className="font-bold">Estado de la semana</p>
         </div>
-        <div className="flex justify-center items-center pt-3">
+        <div className="flex justify-center items-center">
           <WeeklyResume />
         </div>
       </div>


### PR DESCRIPTION
- homepage bottom padding para evitar contenido solapado
- ajustar interlineado de texto en componente IndicatorGroup
- quitar padding top del texto num.semana para centrar en la linea de UserCard
- cambiar lang en index.html
- En Home ajustar bottom margen del titulo con IndicatorGroup para igualar margen al el de UserCard